### PR TITLE
Update API config for local backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,3 @@ mobile/src/components/**/*.js
 mobile/src/constants/*.js
 mobile/src/hooks/**/*.js
 mobile/src/utils/*.js
-mobile/src/.env.example

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Abra o aplicativo utilizando o Expo Go ou um simulador.
 
 ## Configurando o backend
 
-Por padrão o app se conecta ao backend de produção
-`https://backendfinan-aapp-production.up.railway.app`. Caso seja necessário usar
+Por padrão o app se conecta ao backend local em
+`http://localhost:3000/api`. Caso seja necessário usar
 outro servidor, defina a variável `EXPO_PUBLIC_API_URL` (ou crie um arquivo
 `.env`) antes de iniciar o Expo:
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -16,5 +16,5 @@ Em seguida abra o app com o Expo Go ou um emulador.
 
 O app se comunica com o backend especificado na variável de ambiente
 `EXPO_PUBLIC_API_URL`. Caso nenhuma seja fornecida, a URL padrão utilizada é
-``. Você pode copiar o
+`http://localhost:3000/api`. Você pode copiar o
 arquivo `.env.example` e ajustá-lo conforme necessário.

--- a/mobile/src/.env.example
+++ b/mobile/src/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=http://localhost:3000/api

--- a/mobile/src/constants/api.ts
+++ b/mobile/src/constants/api.ts
@@ -1,4 +1,5 @@
-// URL do backend remoto. Pode ser sobrescrita pela variável de ambiente
-// `EXPO_PUBLIC_API_URL` quando necessário.
+// URL do backend utilizada para as requisições.
+// Pode ser sobrescrita pela variável de ambiente `EXPO_PUBLIC_API_URL`.
+// Caso nenhuma seja definida, assume o servidor local utilizado no desenvolvimento.
 export const API_URL =
-  process.env.EXPO_PUBLIC_API_URL;
+  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api';


### PR DESCRIPTION
## Summary
- set default API url to `http://localhost:3000/api`
- document local backend url in READMEs
- provide `.env.example`
- allow example env file in repository

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e6d537b8832c9baa4a48da2b1971