### PR TITLE
Add store data fetch for nearby promotions

### DIFF
--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -14,6 +14,7 @@ import Icon from 'react-native-vector-icons/Feather';
 import CarouselSection from '../../../components/CarouselSection';
 import CircularCarousel from '../../../components/CircularCarousel';
 import { CarouselItem } from '../../../components/CarouselSection/types';
+import { fetchLojas } from '@/app/lojas';
 import { styles } from './styles';
 
 interface Product {
@@ -36,11 +37,6 @@ const promotions: CarouselItem[] = Array.from({ length: 5 }).map((_, i) => ({
   image: `https://picsum.photos/seed/promo${i}/300/200`,
 }));
 
-const nearbyPromotions: CarouselItem[] = Array.from({ length: 6 }).map((_, i) => ({
-  id: `np${i}`,
-  title: `Oferta ${i + 1}`,
-  image: `https://picsum.photos/seed/nearby${i}/300/300`,
-}));
 
 function generateProducts(count: number): Product[] {
   return Array.from({ length: count }).map((_, i) => {
@@ -60,6 +56,7 @@ export default function HomeScreen() {
   const [location, setLocation] = useState('Obtendo localização...');
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(false);
+  const [nearbyPromotions, setNearbyPromotions] = useState<CarouselItem[]>([]);
 
   const loadMore = useCallback(() => {
     if (loading) return;
@@ -91,6 +88,22 @@ export default function HomeScreen() {
     })();
     loadMore();
   }, [loadMore]);
+
+  useEffect(() => {
+    fetchLojas()
+      .then(lojas =>
+        setNearbyPromotions(
+          lojas.map(loja => ({
+            id: String(loja.id),
+            title: loja.nome,
+            image: loja.imagem,
+          }))
+        )
+      )
+      .catch(() => {
+        /* ignore errors */
+      });
+  }, []);
 
   const renderProduct = ({ item }: ListRenderItemInfo<Product>) => (
     <View style={[styles.productCard, { aspectRatio: item.aspectRatio }]}>

--- a/mobile/src/app/lojas.ts
+++ b/mobile/src/app/lojas.ts
@@ -1,0 +1,16 @@
+import { API_URL } from '@/constants/api';
+
+export interface Loja {
+  id: string | number;
+  nome: string;
+  imagem: string;
+}
+
+export async function fetchLojas(): Promise<Loja[]> {
+  const response = await fetch(`${API_URL}/lojas`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch lojas');
+  }
+  return response.json();
+}
+


### PR DESCRIPTION
## Summary
- create `fetchLojas` helper using `API_URL`
- load stores in Home screen to populate 'Promoções perto de você'

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835f4064c0832c95a3197aae04707b