### PR TITLE
Add store carousel on Home

### DIFF
--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, Image, Text } from 'react-native';
+import { lojaImagem } from '@/interfaces/loja';
+import { imagemLoja } from './page';
+import { styles } from './styles';
+
+export default function HomeScreen() {
+  const [lojas, setLojas] = useState<lojaImagem[]>([]);
+
+  useEffect(() => {
+    imagemLoja()
+      .then(dados => setLojas(dados))
+      .catch(err => console.error(err));
+  }, []);
+
+  const renderItem = ({ item }: { item: lojaImagem }) => (
+    <View style={styles.storeItem}>
+      <Image source={{ uri: item.imagem }} style={styles.storeImage} />
+      <Text style={styles.storeName}>{item.nomeFantasia}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.containerTela}>
+      <FlatList
+        data={lojas.slice(0, 7)}
+        keyExtractor={item => item.id}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        renderItem={renderItem}
+        contentContainerStyle={styles.carouselContainer}
+      />
+    </View>
+  );
+}

--- a/mobile/src/app/(tabs)/Home/styles.ts
+++ b/mobile/src/app/(tabs)/Home/styles.ts
@@ -114,4 +114,25 @@ export const styles = StyleSheet.create({
     paddingBottom: 16,
     textAlign: "left",
   },
+  carouselContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  storeItem: {
+    alignItems: "center",
+    marginRight: 16,
+  },
+  storeImage: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    marginBottom: 8,
+    backgroundColor: "#EEE",
+  },
+  storeName: {
+    maxWidth: 72,
+    textAlign: "center",
+    color: "#8B4513",
+    fontSize: 12,
+  },
 });


### PR DESCRIPTION
## Summary
- implement Home screen to display stores carousel
- add carousel and item styles

## Testing
- `npm run lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c8531dbc832c933a818b11bbc109