### PR TITLE
Atualiza URL de backend para produção

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Abra o aplicativo utilizando o Expo Go ou um simulador.
 
 ## Configurando o backend
 
-Por padrão o app se conecta ao backend local em
-`http://localhost:3000/api`. Caso seja necessário usar
+Por padrão o app se conecta ao backend de produção em
+`https://dashnet-production.up.railway.app/api`. Caso seja necessário usar
 outro servidor, defina a variável `EXPO_PUBLIC_API_URL` (ou crie um arquivo
 `.env`) antes de iniciar o Expo:
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -16,5 +16,5 @@ Em seguida abra o app com o Expo Go ou um emulador.
 
 O app se comunica com o backend especificado na variável de ambiente
 `EXPO_PUBLIC_API_URL`. Caso nenhuma seja fornecida, a URL padrão utilizada é
-`http://localhost:3000/api`. Você pode copiar o
+`https://dashnet-production.up.railway.app/api`. Você pode copiar o
 arquivo `.env.example` e ajustá-lo conforme necessário.

--- a/mobile/src/.env.example
+++ b/mobile/src/.env.example
@@ -1,1 +1,1 @@
-EXPO_PUBLIC_API_URL=http://localhost:3000/api
+EXPO_PUBLIC_API_URL=https://dashnet-production.up.railway.app/api

--- a/mobile/src/constants/api.ts
+++ b/mobile/src/constants/api.ts
@@ -2,4 +2,5 @@
 // Pode ser sobrescrita pela variável de ambiente `EXPO_PUBLIC_API_URL`.
 // Caso nenhuma seja definida, assume o servidor local utilizado no desenvolvimento.
 export const API_URL =
-  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api';
+  process.env.EXPO_PUBLIC_API_URL ??
+  'https://dashnet-production.up.railway.app/api';


### PR DESCRIPTION
## Summary
- configure default API endpoint for production server
- update example environment file with new URL
- update docs with the production endpoint

## Testing
- `npm run lint` *(fails: expo not found)*


------
https://chatgpt.com/codex/tasks/task_e_68876ba8eb1c832c99d5c0bc707a3a5d