### PR TITLE
Connect MasonryGrid to foto-valor API

### DIFF
--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Text, View, ScrollView, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 import { lojaImagem } from '@/interfaces/loja';
-import { SearchBar, PointsCounter, LocationStatus, CarouselCircularHorizontal, CarouselRectHorizontal, MasonryGrid } from '../../../components';
+import { SearchBar, PointsCounter, LocationStatus, CarouselCircularHorizontal, CarouselRectHorizontal, MasonryGrid, InfiniteScrollLoading } from '../../../components';
 import { styles } from './styles';
 import { MasonryGridItem } from '@/components/MasonryGrid';
 import { produtosFotoValor } from '@/app/registros';
@@ -34,7 +34,7 @@ export default function Home({ lojas }: HomeProps) {
             setLoadingMore(true);
             const produtos = await produtosFotoValor(pageNumber);
             const mapped = produtos.map((p) => ({
-                id: p.id,
+                id: `${pageNumber}-${p.id}`,
                 image: p.imagem,
                 label: `R$ ${p.preco}`,
                 height: cardHeights[Math.floor(Math.random() * cardHeights.length)],
@@ -65,7 +65,7 @@ export default function Home({ lojas }: HomeProps) {
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
             onScroll={handleScroll}
-            scrollEventThrottle={200}
+            scrollEventThrottle={16}
         >
             <View style={styles.spacer24} />
             <View style={styles.locationStatusWrapper}>
@@ -104,9 +104,7 @@ export default function Home({ lojas }: HomeProps) {
                     style={styles.masonryGrid}
                 />
                 {loadingMore && (
-                    <View style={styles.loadingMoreWrapper}>
-                        <Text style={styles.loadingMoreText}>Carregando mais...</Text>
-                    </View>
+                    <InfiniteScrollLoading />
                 )}
             </View>
         </ScrollView>

--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -1,22 +1,15 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Text, View, ScrollView } from 'react-native';
 import { lojaImagem } from '@/interfaces/loja';
 import { SearchBar, PointsCounter, LocationStatus, CarouselCircularHorizontal, CarouselRectHorizontal, MasonryGrid } from '../../../components';
 import { styles } from './styles';
 import { MasonryGridItem } from '@/components/MasonryGrid';
+import { produtosFotoValor } from '@/app/registros';
 
 export interface HomeProps {
     lojas: lojaImagem[];
 }
 const cardHeights = [120, 160, 220, 280, 320, 180];
-
-const feedData: MasonryGridItem[] = Array.from({ length: 24 }).map((_, i) => ({
-    id: String(i),
-    image: `https://picsum.photos/id/${i + 10}/400/600`,
-    label: `Item ${i + 1}`,
-    height: cardHeights[Math.floor(Math.random() * cardHeights.length)],
-}));
-
 export default function Home({ lojas }: HomeProps) {
     const [search, setSearch] = useState('');
 
@@ -32,37 +25,29 @@ export default function Home({ lojas }: HomeProps) {
         { id: '3', image: 'https://placehold.co/220x140', value: 'R$ 39,90' },
         { id: '4', image: 'https://placehold.co/220x140', value: 'R$ 49,90' },
     ];
-    // Exemplo de dados para o MasonryGrid
-    const [masonryData, setMasonryData] = useState(() => Array.from({ length: 12 }, (_, i) => ({
-        id: String(i + 1),
-        image: 'https://placehold.co/300x180',
-        label: `Produto ${i + 1}`,
-        height: 100 + Math.floor(Math.random() * 100),
-    })));
-    const [loadingMore, setLoadingMore] = useState(false);
+    const [masonryData, setMasonryData] = useState<MasonryGridItem[]>([]);
 
-    const handleLoadMore = () => {
-        if (loadingMore) return;
-        setLoadingMore(true);
-        setTimeout(() => {
-            setMasonryData(prev => [
-                ...prev,
-                ...Array.from({ length: 6 }, (_, i) => ({
-                    id: String(prev.length + i + 1),
-                    image: 'https://placehold.co/300x180',
-                    label: `Produto ${prev.length + i + 1}`,
-                    height: 100 + Math.floor(Math.random() * 100),
-                }))
-            ]);
-            setLoadingMore(false);
-        }, 1200);
-    };
+    useEffect(() => {
+        (async () => {
+            try {
+                const produtos = await produtosFotoValor();
+                const mapped = produtos.map((p) => ({
+                    id: p.id,
+                    image: p.imagem,
+                    label: `R$ ${p.preco}`,
+                    height: cardHeights[Math.floor(Math.random() * cardHeights.length)],
+                }));
+                setMasonryData(mapped);
+            } catch (err) {
+                console.error('Erro ao carregar produtos', err);
+            }
+        })();
+    }, []);
 
     return (
         <ScrollView
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
-            onMomentumScrollEnd={handleLoadMore}
         >
             <View style={styles.spacer24} />
             <View style={styles.locationStatusWrapper}>
@@ -95,16 +80,11 @@ export default function Home({ lojas }: HomeProps) {
                     Talvez você nem precisasse
                 </Text>
                 <MasonryGrid
-                    data={feedData}
+                    data={masonryData}
                     numColumns={2}
                     gap={12}
                     style={styles.masonryGrid}
                 />
-                {loadingMore && (
-                    <View style={styles.loadingMoreWrapper}>
-                        <Text style={styles.loadingMoreText}>Carregando mais...</Text>
-                    </View>
-                )}
             </View>
         </ScrollView>
     );

--- a/mobile/src/app/(tabs)/Home/styles.ts
+++ b/mobile/src/app/(tabs)/Home/styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from "react-native";
 
 export const styles = StyleSheet.create({
   scrollContent: {
-    paddingBottom: 32,
+    paddingBottom: 80,
   },
   spacer24: {
     height: 24,

--- a/mobile/src/app/registros.ts
+++ b/mobile/src/app/registros.ts
@@ -74,7 +74,7 @@ export async function produtosFotoValor(page = 1): Promise<FotoValor[]> {
       : [];
 
   return produtos.map((p: any, index: number) => ({
-    id: String(p.id ?? index),
+    id: p?.id != null ? String(p.id) : `${page}-${index}`,
     nome: String(p.nome ?? ''),
     preco: String(p.preco ?? ''),
     imagem: String(p.imagem ?? ''),

--- a/mobile/src/app/registros.ts
+++ b/mobile/src/app/registros.ts
@@ -60,8 +60,8 @@ export async function imagemLoja(): Promise<lojaImagem[]> {
   }));
 }
 
-export async function produtosFotoValor(): Promise<FotoValor[]> {
-  const response = await fetch(`${API_URL}/products/foto-valor`);
+export async function produtosFotoValor(page = 1): Promise<FotoValor[]> {
+  const response = await fetch(`${API_URL}/products/foto-valor?page=${page}`);
   if (!response.ok) {
     throw new Error('Failed to fetch foto-valor');
   }

--- a/mobile/src/app/registros.ts
+++ b/mobile/src/app/registros.ts
@@ -1,6 +1,7 @@
 import { API_URL } from "@/constants/api";
 import { lojaImagem } from "@/interfaces/loja";
 import { Produto } from "@/interfaces/product";
+import { FotoValor } from "@/interfaces/fotoValor";
 
 export async function ProdutosDetalhado(): Promise<Produto[]> {
   const response = await fetch(`${API_URL}/products`);
@@ -56,5 +57,26 @@ export async function imagemLoja(): Promise<lojaImagem[]> {
     id: String(l.id ?? index),
     nomeFantasia: String(l.nomeFantasia ?? ''),
     imagem: String(l.imagem ?? ''),
+  }));
+}
+
+export async function produtosFotoValor(): Promise<FotoValor[]> {
+  const response = await fetch(`${API_URL}/products/foto-valor`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch foto-valor');
+  }
+  const data = await response.json();
+
+  const produtos = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.dados)
+      ? data.dados
+      : [];
+
+  return produtos.map((p: any, index: number) => ({
+    id: String(p.id ?? index),
+    nome: String(p.nome ?? ''),
+    preco: String(p.preco ?? ''),
+    imagem: String(p.imagem ?? ''),
   }));
 }

--- a/mobile/src/components/InfiniteScrollLoading/index.tsx
+++ b/mobile/src/components/InfiniteScrollLoading/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ActivityIndicator, View, Text } from 'react-native';
+
+export interface InfiniteScrollLoadingProps {
+    text?: string;
+    color?: string;
+    size?: 'small' | 'large';
+}
+
+export default function InfiniteScrollLoading({
+    text = 'Carregando mais...',
+    color = '#8B4513',
+    size = 'small',
+}: InfiniteScrollLoadingProps) {
+    return (
+        <View style={{ alignItems: 'center', padding: 16, flexDirection: 'row', justifyContent: 'center' }}>
+            <ActivityIndicator color={color} size={size} style={{ marginRight: 10 }} />
+            <Text style={{ color, fontSize: 15 }}>{text}</Text>
+        </View>
+    );
+}

--- a/mobile/src/components/index.ts
+++ b/mobile/src/components/index.ts
@@ -10,5 +10,6 @@ export { default as SafeAreaContainer } from "./SafeArea";
 export { default as SearchBar } from "./SearchBar";
 export { default as CarouselRectHorizontal } from "./CarouselRectHorizontal";
 export { default as MasonryGrid } from "./MasonryGrid";
+export { default as InfiniteScrollLoading } from "./InfiniteScrollLoading";
 // Para os componentes em 'ui', exporte individualmente se necessário
 export { default as TabBarBackground } from "./ui/TabBarBackground";

--- a/mobile/src/interfaces/fotoValor.ts
+++ b/mobile/src/interfaces/fotoValor.ts
@@ -1,0 +1,6 @@
+export interface FotoValor {
+  id: string;
+  nome: string;
+  preco: string;
+  imagem: string;
+}

--- a/mobile/src/scripts/test-db.js
+++ b/mobile/src/scripts/test-db.js
@@ -2,7 +2,7 @@ const API_URL = process.env.EXPO_PUBLIC_API_URL || 'https://dashnet-production.u
 
 async function testConnection() {
   try {
-    const response = await fetch(`${API_URL}/lojas`);
+    const response = await fetch(`${API_URL}/products/foto-valor`);
     if (!response.ok) {
       console.error(`Request failed with status ${response.status}`);
       return;


### PR DESCRIPTION
## Summary
- add `FotoValor` interface for product photo/price
- implement `produtosFotoValor` fetching `/products/foto-valor`
- load MasonryGrid data from API in Home screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887aa9321ac832ca5848901d6fb77ae