### PR TITLE
Implement animated search modal

### DIFF
--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Text, View, ScrollView, NativeSyntheticEvent, NativeScrollEvent, RefreshControl } from 'react-native';
 import { lojaImagem } from '@/interfaces/loja';
-import { SearchBar, LocationStatus, CarouselCircularHorizontal, CarouselRectHorizontal, MasonryGrid, InfiniteScrollLoading } from '../../../components';
+import { SearchBar, LocationStatus, CarouselCircularHorizontal, CarouselRectHorizontal, MasonryGrid, InfiniteScrollLoading, SearchModal } from '../../../components';
 import { styles } from './styles';
 import { MasonryGridItem } from '@/components/MasonryGrid';
 import { produtosFotoValor } from '@/app/registros';
@@ -13,6 +13,7 @@ export interface HomeProps {
 const cardHeights = [120, 160, 220, 280, 320, 180];
 export default function Home({ lojas }: HomeProps) {
     const [search, setSearch] = useState('');
+    const [searchVisible, setSearchVisible] = useState(false);
 
     // Filtro simples, pode ser melhorado conforme necessidade
     const lojasFiltradas = lojas.filter(loja =>
@@ -81,6 +82,7 @@ export default function Home({ lojas }: HomeProps) {
     }, [refreshHome]);
 
     return (
+        <>
         <ScrollView
             ref={scrollRef}
             contentContainerStyle={styles.scrollContent}
@@ -97,7 +99,13 @@ export default function Home({ lojas }: HomeProps) {
             </View>
             <View style={styles.searchRow}>
                 <View style={styles.searchBarContainer}>
-                    <SearchBar value={search} onChangeText={setSearch} placeholder="Tem no Dash..." points={35} />
+                    <SearchBar
+                        value={search}
+                        onChangeText={setSearch}
+                        placeholder="Tem no Dash..."
+                        points={35}
+                        onFocus={() => setSearchVisible(true)}
+                    />
                 </View>
 
             </View>
@@ -130,5 +138,12 @@ export default function Home({ lojas }: HomeProps) {
                 )}
             </View>
         </ScrollView>
+        <SearchModal
+            visible={searchVisible}
+            value={search}
+            onChangeText={setSearch}
+            onRequestClose={() => setSearchVisible(false)}
+        />
+        </>
     );
 }

--- a/mobile/src/components/SearchBar/index.tsx
+++ b/mobile/src/components/SearchBar/index.tsx
@@ -7,9 +7,12 @@ interface SearchBarProps {
     onChangeText: (text: string) => void;
     placeholder?: string;
     points?: number;
+    showPoints?: boolean;
+    onFocus?: () => void;
+    autoFocus?: boolean;
 }
 
-export default function SearchBar({ value, onChangeText, placeholder, points = 0 }: SearchBarProps) {
+export default function SearchBar({ value, onChangeText, placeholder, points = 0, showPoints = true, onFocus, autoFocus }: SearchBarProps) {
     return (
         <View style={styles.wrapper}>
             <View style={styles.container}>
@@ -23,15 +26,19 @@ export default function SearchBar({ value, onChangeText, placeholder, points = 0
                     autoCapitalize="none"
                     autoCorrect={false}
                     clearButtonMode="while-editing"
+                    onFocus={onFocus}
+                    autoFocus={autoFocus}
                 />
             </View>
-            <View style={styles.pointsContainer}>
-                <View style={styles.row}>
-                    <Text style={styles.pointsIcon}>🎯</Text>
-                    <Text style={styles.pointsIconLabel}>Pts</Text>
+            {showPoints && (
+                <View style={styles.pointsContainer}>
+                    <View style={styles.row}>
+                        <Text style={styles.pointsIcon}>🎯</Text>
+                        <Text style={styles.pointsIconLabel}>Pts</Text>
+                    </View>
+                    <Text style={styles.points}>{points}</Text>
                 </View>
-                <Text style={styles.points}>{points}</Text>
-            </View>
+            )}
         </View>
     );
 }

--- a/mobile/src/components/SearchModal/index.tsx
+++ b/mobile/src/components/SearchModal/index.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef } from 'react';
+import { Modal, Animated, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
+import SearchBar from '../SearchBar';
+
+interface SearchModalProps {
+  visible: boolean;
+  value: string;
+  onChangeText: (text: string) => void;
+  onRequestClose: () => void;
+}
+
+export default function SearchModal({ visible, value, onChangeText, onRequestClose }: SearchModalProps) {
+  const searchAnim = useRef(new Animated.Value(0)).current;
+  const cardAnim = useRef(new Animated.Value(0)).current;
+  const { height } = Dimensions.get('window');
+
+  useEffect(() => {
+    if (visible) {
+      Animated.sequence([
+        Animated.timing(searchAnim, { toValue: 1, duration: 300, useNativeDriver: true }),
+        Animated.timing(cardAnim, { toValue: 1, duration: 300, useNativeDriver: true }),
+      ]).start();
+    } else {
+      searchAnim.setValue(0);
+      cardAnim.setValue(0);
+    }
+  }, [visible, searchAnim, cardAnim]);
+
+  const translateY = searchAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, height / 2 - 80],
+  });
+
+  const cardSlide = cardAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-20, 0],
+  });
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={onRequestClose}>
+      <TouchableWithoutFeedback onPress={onRequestClose}>
+        <View style={styles.overlay} />
+      </TouchableWithoutFeedback>
+      <Animated.View style={[styles.searchWrapper, { transform: [{ translateY }] }]}>
+        <SearchBar value={value} onChangeText={onChangeText} placeholder="Tem no Dash..." showPoints={false} autoFocus />
+      </Animated.View>
+      <Animated.View
+        style={[
+          styles.card,
+          {
+            opacity: cardAnim,
+            transform: [{ translateY: Animated.add(translateY, cardSlide) }],
+          },
+        ]}
+      >
+        {/* Conteúdo do modal pode ser inserido aqui */}
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.2)',
+  },
+  searchWrapper: {
+    position: 'absolute',
+    top: 40,
+    left: 16,
+    right: 16,
+  },
+  card: {
+    position: 'absolute',
+    top: 40 + 56,
+    left: 16,
+    right: 16,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#FFFAF0',
+    elevation: 4,
+  },
+});

--- a/mobile/src/components/index.ts
+++ b/mobile/src/components/index.ts
@@ -11,5 +11,6 @@ export { default as SearchBar } from "./SearchBar";
 export { default as CarouselRectHorizontal } from "./CarouselRectHorizontal";
 export { default as MasonryGrid } from "./MasonryGrid";
 export { default as InfiniteScrollLoading } from "./InfiniteScrollLoading";
+export { default as SearchModal } from "./SearchModal";
 // Para os componentes em 'ui', exporte individualmente se necessário
 export { default as TabBarBackground } from "./ui/TabBarBackground";


### PR DESCRIPTION
## Summary
- extend `SearchBar` with optional display props
- implement animated `SearchModal`
- show `SearchModal` from Home screen when focusing search
- export the new component

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ec4b6128832cb7af5c36c331a9e8